### PR TITLE
Remove ladder from church

### DIFF
--- a/src/maps/so_hidden_so_ghillies.gsc
+++ b/src/maps/so_hidden_so_ghillies.gsc
@@ -42,28 +42,25 @@ main()
 start_so_hidden()
 {
 	remove_church_door();
-	level thread block_churchtower_ladder();//blocked cause it confuses the AI
+	remove_churchtower_ladder();
 	
 	//Remove placed weapons
 	level thread removePlacedWeapons();
 }
 
-//since im to stupid to find collision stuff im doing it the lazy way
-block_churchtower_ladder()
+//Remove chuch ladder
+remove_churchtower_ladder()
 {
-	level.church_tower_blocker = spawn("script_model",(-34235.2,-1472.22,308.056));
-	for(;;)
+	ladder_ents = getentarray( "churchladder", "script_noteworthy" );
+	foreach ( ent in ladder_ents )
 	{
-		foreach(player in getPlayers())
-		{
-			if(distance(player.origin,level.church_tower_blocker.origin)<=20)
-			{
-				player setOrigin((-34156.5,-1442.98,224.125));
-				iprintlnBold("Cant go up here!");
-				wait 0.05;
-			}
-		}
-		wait 0.05;
+		ent Delete();
+	}
+
+	ladder_ents = getentarray( "churchladder_clip", "script_noteworthy" );
+	foreach ( ent in ladder_ents )
+	{
+		ent disconnectpaths();
 	}
 }
 


### PR DESCRIPTION
Instead of blocking the ladder off with collision, removing it looks much cleaner and cannot be bypassed. Code adapted from [here](https://github.com/FreeTheTech101/IW4-Dump-Files/blob/98c2e6eef475f1e95d513885512c9647e332aa61/maps/so_killspree_invasion.gsc#L150).

Preview:
![Call of Duty  Modern Warfare 2 Screenshot 2020 09 29 - 15 01 09 98](https://user-images.githubusercontent.com/7614507/94604743-1bb99900-0266-11eb-9d70-6af26bcd57ef.png)
